### PR TITLE
Fix bug?

### DIFF
--- a/python/apogee_drp/apred/rv.py
+++ b/python/apogee_drp/apred/rv.py
@@ -737,7 +737,7 @@ def visitcomb(allvisit,starver,load=None, apred='r13',telescope='apo25m',nres=[5
 
             # Get a smoothed, filtered spectrum to use as replacement for bad values
             cont = gaussian_filter(median_filter(apvisit.flux[chip,:],[501],mode='reflect'),100)
-            errcont = gaussian_filter(median_filter(apvisit.flux[chip,:],[501],mode='reflect'),100)
+            errcont = gaussian_filter(median_filter(apvisit.err[chip,:],[501],mode='reflect'),100)
             bd, = np.where(apvisit.bitmask[chip,:]&pixelmask.badval())
             if len(bd) > 0: 
                 apvisit.flux[chip,bd] = cont[bd] 

--- a/python/apogee_drp/apred/rv_drew.py
+++ b/python/apogee_drp/apred/rv_drew.py
@@ -775,7 +775,7 @@ def visitcomb(allvisit,starver,load=None, apred='r13',telescope='apo25m',nres=[5
 
             # Get a smoothed, filtered spectrum to use as replacement for bad values
             cont = gaussian_filter(median_filter(apvisit.flux[chip,:],[501],mode='reflect'),100)
-            errcont = gaussian_filter(median_filter(apvisit.flux[chip,:],[501],mode='reflect'),100)
+            errcont = gaussian_filter(median_filter(apvisit.err[chip,:],[501],mode='reflect'),100)
             bd, = np.where(apvisit.bitmask[chip,:]&pixelmask.badval())
             if len(bd) > 0: 
                 apvisit.flux[chip,bd] = cont[bd] 


### PR DESCRIPTION
When visits are resampled and stacked, a smoothed and filtered version of the spectrum is used for bad pixels.

I think the smoothed and filtered flux values are incorrectly being assigned as the flux error values for bad pixels, instead of using the smoothed flux error values. This PR fixes that.