### PR TITLE
Limiting value for normalized sinc function used in resampling

### DIFF
--- a/python/apogee_drp/apred/sincint.py
+++ b/python/apogee_drp/apred/sincint.py
@@ -38,6 +38,9 @@ def sincint(x, nres, speclist) :
         u2 = np.pi*xkernel
         sinc = np.exp(-(u1**2)) * np.sin(u2) / u2
         sinc /= (nres/2.)
+        
+        # the value at x = 0 is defined to be the limiting value
+        sinc[u2 == 0] = 1
 
         lobe = np.arange(ksize) - nhalf + ix[i]
         vals = np.zeros(ksize)


### PR DESCRIPTION
The normalized sinc function used for resampling is $\textrm{sinc}{x} = \frac{\sin{\pi{}x}}{\pi{}x}$. The value at $x = 0$ is defined to be the limiting value $\operatorname {sinc} 0:=\lim _{x\to 0}{\frac {\sin(ax)}{ax}}=1$, but this is not currently implemented in the sinc interpolation used for resampling.

That means when a star has precisely zero radial velocity, or the wavelengths are shifted by some multiple of $\pi$, the resampling procedure will return a NaN for that flux value. This PR fixes that.

Below is a code snippet that proves it. In method 0, exactly zero radial velocity is adopted. In method 1, a tiny non-zero radial velocity is adopted (1e-4 km/s).

```python
import numpy as np
import matplotlib.pyplot as plt

from apogee_drp.apred.sincint import sincint
from apogee_drp.apred.wave import wave2pix


crval, cdelt, n_pixels = (4.179, 6e-6, 8575)
wl = 10**(crval + cdelt * np.arange(n_pixels))

# nres changes per chip, but this is the value for the first chip and is sufficient
# for these purposes
nres = 5
delta_rv = 0.0001 # [km/s]

bitmask_flag = np.zeros(n_pixels, dtype=np.int)

# Create some blocks, starting with a delta function
n, gap, s = (1, 50, 10)
while s < n_pixels:
    bitmask_flag[s:s + n] = 1
    s += gap + n
    n += 1

wl_0 = wl
wl_1 = wl * (1 + delta_rv/3e5)
pixel_shift_0 = wave2pix(wl, wl_0)
pixel_shift_1 = wave2pix(wl, wl_1)

(resampled_0, _), = sincint(pixel_shift_0, nres, [[bitmask_flag, None]])
(resampled_1, _), = sincint(pixel_shift_1, nres, [[bitmask_flag, None]])

fig, (ax_0, ax_1) = plt.subplots(1, 2, figsize=(12, 6))
ax_0.plot(wl_0, resampled_0, c="tab:red", label="resampled")
ax_1.plot(wl_1, resampled_1, c="tab:red", label="resampled")

ax_0.plot(wl_0, bitmask_flag, c="tab:blue", label="original")
ax_1.plot(wl_1, bitmask_flag, c="tab:blue", label="original")

for ax in (ax_0, ax_1):
    ax.set_xlim(wl[0], wl[0] + 50)
    ax.axhline(0.1, c="#666666", ls=":")
    ax.set_xlabel("wavelength [A]")
    ax.set_ylabel("value")

ax_0.set_title(f"delta_rv = 0 (num_nan: {np.sum(~np.isfinite(resampled_0))})")
ax_1.set_title(f"delta_rv = {delta_rv:.1e} km/s (num_nan: {np.sum(~np.isfinite(resampled_1))})")

fig.tight_layout()

print(f"Original: {np.sum(bitmask_flag > 0)}")
print(f"After resampling 0: {np.sum(resampled_0 > 0.1)}")
print(f"After resampling 1: {np.sum(resampled_1 > 0.1)}")

print(f"NANS")
print(f" resampling 0: {np.sum(~np.isfinite(resampled_0))}")
print(f" resampling 1: {np.sum(~np.isfinite(resampled_1))}")
```

The output of the code is:
```
Original: 4095
After resampling 0: 2892
After resampling 1: 4275
NANS
 resampling 0: 2830
 resampling 1: 0
```

And the figure looks like this (blue: original, red: resampled):
<img width="734" alt="image" src="https://user-images.githubusercontent.com/504436/185297517-19a9960f-57e4-49a2-91c8-eff8a2ecf80d.png">

After making the one-line change that this pull request proposes, this is the figure output:
<img width="745" alt="image" src="https://user-images.githubusercontent.com/504436/185297634-33700b00-ff65-49ea-8a52-da6c98f29df9.png">
